### PR TITLE
Fix for smoother resize handle

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -72,9 +72,9 @@ function handleMouseMove(view, event, handleWidth, cellMinWidth, lastColumnResiz
     if (target) {
       let {left, right} = target.getBoundingClientRect()
       if (event.clientX - left <= handleWidth)
-        cell = edgeCell(view, event, "left")
+        cell = edgeCell(view, event, "left", handleWidth)
       else if (right - event.clientX <= handleWidth)
-        cell = edgeCell(view, event, "right")
+        cell = edgeCell(view, event, "right", handleWidth)
     }
 
     if (cell != pluginState.activeHandle) {
@@ -147,8 +147,13 @@ function domCellAround(target) {
   return target
 }
 
-function edgeCell(view, event, side) {
-  let found = view.posAtCoords({left: event.clientX, top: event.clientY})
+function edgeCell(view, event, side, handleWidth) {
+  // posAtCoords returns inconsistent positions when cursor is moving
+  // across a collapsed table border. Use an offset to adjust the
+  // target viewport coordinates away from the table border.
+  let offset = side == "right" ? -handleWidth : handleWidth
+  let found = view.posAtCoords({left: event.clientX + offset, top: event.clientY})
+  
   if (!found) return -1
   let {pos} = found
   let $cell = cellAround(view.state.doc.resolve(pos))


### PR DESCRIPTION
Summary
This is a fix for the jumpiness in the resize handle. The fix was first purposed by https://github.com/ProseMirror/prosemirror-tables/pull/99. Essentially, the fix is to
add an offset to where the cell position because the editor view's `posAtCoords` returns 
inconsistent positions when cursor is moving across a collapsed table border.

Asana tasks:
https://app.asana.com/0/1117482789486653/1200001818755084

Test Plan
manual tested on sand. It is quite difficult to mock up the editor view for unit test
propsed task: https://app.asana.com/0/1178558006936502/1200063617912615

Reason this is safe to merge before code review
N/A -- I plan to have this code reviewed before merging.

