### PR TITLE
fix handleDecorations when table does not exist

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -207,7 +207,7 @@ function handleDecorations(state, cell) {
   let $cell = state.doc.resolve(cell)
   let table = $cell.node(-1)
   if (!table) {
-    return DecorationSet.create(state.doc, decorations)
+    return DecorationSet.empty
   }
   let map = TableMap.get(table), start = $cell.start(-1)
   let col = map.colCount($cell.pos - start) + $cell.nodeAfter.attrs.colspan

--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -205,7 +205,11 @@ function zeroes(n) {
 function handleDecorations(state, cell) {
   let decorations = []
   let $cell = state.doc.resolve(cell)
-  let table = $cell.node(-1), map = TableMap.get(table), start = $cell.start(-1)
+  let table = $cell.node(-1)
+  if (!table) {
+    return DecorationSet.create(state.doc, decorations)
+  }
+  let map = TableMap.get(table), start = $cell.start(-1)
   let col = map.colCount($cell.pos - start) + $cell.nodeAfter.attrs.colspan
   for (let row = 0; row < map.height; row++) {
     let index = col + row * map.width - 1

--- a/test/test-columnresizing.js
+++ b/test/test-columnresizing.js
@@ -1,6 +1,6 @@
 const ist = require("ist");
 const { columnResizing, columnResizingPluginKey } = require("../dist/");
-const { EditorState } = require("prosemirror-state");
+const { EditorState, NodeSelection } = require("prosemirror-state");
 const { doc, table, tr, td, cEmpty, p } = require("./build");
 
 describe("columnresizing", () => {
@@ -176,4 +176,34 @@ describe("columnresizing", () => {
       });
     });
   });
+  describe("table is deleted", () => {
+    let state = null;
+    let plugin = null;
+    let simpleTable = table(
+      tr(cEmpty, cEmpty),
+      tr(cEmpty, cEmpty),
+      tr(cEmpty, cEmpty)
+    );
+    beforeEach(() => {
+      const docWithSimpleTable = doc(simpleTable);
+      plugin = columnResizing();
+      state = EditorState.create({
+        doc: docWithSimpleTable,
+        plugins: [plugin],
+        selection: NodeSelection.create(docWithSimpleTable, 0)
+      });
+    });
+    afterEach(() => {
+      state = null;
+      plugin = null;
+    });
+    it("decorations are removed", () => {
+      let transaction = state.tr.deleteSelection().setMeta(columnResizingPluginKey, {
+        setHandle: 2,
+        setDragging: null,
+      });
+      let newState = state.apply(transaction);
+      ist(plugin.props.decorations(newState).find().length, 0);
+    })
+  })
 });


### PR DESCRIPTION
## Summary

`handleDecorations` in the `columnResizing` attempts to generate a `TableMap` from a table node, but this results in an error if the table node no longer exists. This occurs when the table has just been deleted. If the table no longer exists, `handleDecorations` should return an empty decoration set.

## Testing
Manual tests in sand and demo app.
Unit tests.
