### PR TITLE
Handle Atom Nodes in goToNextCell

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -472,22 +472,20 @@ export function goToNextCell(direction) {
   return function(state, dispatch) {
     if (!isInTable(state)) return false
     let cell = findNextCell(selectionCell(state), direction)
-    if (cell == null) return
+    if (cell == null) return false
     if (dispatch) {
-      if (dispatch) {
-        const cellNode = state.doc.nodeAt(cell)
-        const cellLastChild = cellNode.lastChild
-        if (cellLastChild == null) return
-        const isLastNodeAtomNode = cellLastChild.type.isAtom
-        const cellContentEndPos = cell + cellNode.nodeSize - 2
-        dispatch(
-          state.tr.setSelection(
-            isLastNodeAtomNode
-              ? NodeSelection.create(state.doc, cellContentEndPos)
-              : TextSelection.create(state.doc, cellContentEndPos)
-          ).scrollIntoView()
-        )
-      }
+      const cellNode = state.doc.nodeAt(cell)
+      const cellLastChild = cellNode.lastChild
+      if (cellLastChild == null) return false
+      const isLastNodeAtomNode = cellLastChild.type.isAtom
+      const cellContentEndPos = cell + cellNode.nodeSize - 2
+      dispatch(
+        state.tr.setSelection(
+          isLastNodeAtomNode
+            ? NodeSelection.create(state.doc, cellContentEndPos)
+            : TextSelection.create(state.doc, cellContentEndPos)
+        ).scrollIntoView()
+      )
     }
     return true
   }

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,6 +1,6 @@
 // This file defines a number of table-related commands.
 
-import {TextSelection} from "prosemirror-state"
+import {TextSelection, NodeSelection} from "prosemirror-state"
 import {Fragment} from "prosemirror-model"
 
 import {Rect, TableMap} from "./tablemap"
@@ -474,8 +474,20 @@ export function goToNextCell(direction) {
     let cell = findNextCell(selectionCell(state), direction)
     if (cell == null) return
     if (dispatch) {
-      let $cell = state.doc.resolve(cell)
-      dispatch(state.tr.setSelection(TextSelection.between($cell, moveCellForward($cell))).scrollIntoView())
+      if (dispatch) {
+        const cellNode = state.doc.nodeAt(cell)
+        const cellLastChild = cellNode.lastChild
+        if (cellLastChild == null) return
+        const isLastNodeAtomNode = cellLastChild.type.isAtom
+        const cellContentEndPos = cell + cellNode.nodeSize - 2
+        dispatch(
+          state.tr.setSelection(
+            isLastNodeAtomNode
+              ? NodeSelection.create(state.doc, cellContentEndPos)
+              : TextSelection.create(state.doc, cellContentEndPos)
+          ).scrollIntoView()
+        )
+      }
     }
     return true
   }

--- a/test/build.js
+++ b/test/build.js
@@ -4,13 +4,34 @@ const {schema: baseSchema} = require("prosemirror-schema-basic")
 const {tableNodes, cellAround, CellSelection} = require("../dist/")
 
 let schema = new Schema({
-  nodes: baseSchema.spec.nodes.append(tableNodes({
-    tableGroup: "block",
-    cellContent: "block+",
-    cellAttributes: {
-      test: {default: "default"}
-    }
-  })),
+  nodes: baseSchema.spec.nodes.append({
+    ...tableNodes({
+      tableGroup: "block",
+      cellContent: "block+",
+      cellAttributes: {
+        test: {default: "default"}
+      }
+    }),
+    image: {
+      atom: true,
+      inline: true,
+      attrs: {
+        src: {},
+        alt: {default: null},
+        title: {default: null}
+      },
+      group: "inline",
+      draggable: true,
+      parseDOM: [{tag: "img[src]", getAttrs(dom) {
+        return {
+          src: dom.getAttribute("src"),
+          title: dom.getAttribute("title"),
+          alt: dom.getAttribute("alt")
+        }
+      }}],
+      toDOM(node) { let {src, alt, title} = node.attrs; return ["img", {src, alt, title}] }
+    },
+  }),
   marks: baseSchema.spec.marks
 })
 
@@ -18,7 +39,8 @@ let e = module.exports = require("prosemirror-test-builder").builders(schema, {
   p: {nodeType: "paragraph"},
   tr: {nodeType: "table_row"},
   td: {nodeType: "table_cell"},
-  th: {nodeType: "table_header"}
+  th: {nodeType: "table_header"},
+  image: {nodeType: "image"}
 })
 
 e.c = function(colspan, rowspan) {

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -1,9 +1,9 @@
 const ist = require("ist")
-const {EditorState} = require("prosemirror-state")
+const {EditorState, NodeSelection, TextSelection} = require("prosemirror-state")
 
-const {doc, table, tr, p, td, th, c, h, c11, h11, cEmpty, hEmpty, cCursor, hCursor, cHead, cAnchor, eq, selectionFor} = require("./build")
+const {doc, table, tr, p, td, th, c, h, c11, h11, cEmpty, hEmpty, cCursor, hCursor, cHead, cAnchor, eq, selectionFor, image} = require("./build")
 const {addColumnAfter, addColumnBefore, deleteColumn, addRowAfter, addRowBefore, deleteRow,
-       mergeCells, splitCell, splitCellWithType, setCellAttr, toggleHeader, toggleHeaderRow, toggleHeaderColumn} = require("../dist/")
+       mergeCells, splitCell, splitCellWithType, setCellAttr, toggleHeader, toggleHeaderRow, toggleHeaderColumn, goToNextCell} = require("../dist/")
 
 function test(doc, command, result) {
   let state = EditorState.create({doc, selection: selectionFor(doc)})
@@ -461,4 +461,56 @@ describe("toggleHeader", () => {
             toggleHeader("column", { useDeprecateLogic: false }),
             doc(table(tr(hCursor, h11), tr(c11, c11)))))
   })
+})
+
+describe("goToNextCell", () => {
+     const simpleTable = table(
+          tr(td({ colspan: 1, rowspan: 1 }, p('abc')), td({ colspan: 1, rowspan: 1 }, p('def'))),
+          tr(td({ colspan: 1, rowspan: 1 }, image({ src: "test" })), cEmpty),
+     );
+     const docWithSimpleTable = doc(simpleTable, p('x'));
+
+     it("returns false if selection is not in table", () => {
+          let state = EditorState.create({
+               doc: docWithSimpleTable,
+               selection: TextSelection.create(docWithSimpleTable, docWithSimpleTable.content.size - 1)
+          });
+          const dispatch = (tr) => state = state.apply(tr);
+          const commandResult = goToNextCell(1)(state, dispatch);
+          ist(commandResult, false);
+     })
+
+     it("returns true and moves forward one cell if selection is in table", () => {
+          let state = EditorState.create({
+               doc: docWithSimpleTable,
+               selection: TextSelection.create(docWithSimpleTable, 7)
+          });
+          const dispatch = (tr) => state = state.apply(tr);
+          const commandResult = goToNextCell(1)(state, dispatch);
+          ist(commandResult, true);
+          ist(state.selection.from, 14);
+     })
+
+     it("returns true and moves back one cell if selection is in table", () => {
+          let state = EditorState.create({
+               doc: docWithSimpleTable,
+               selection: TextSelection.create(docWithSimpleTable, 14)
+          });
+          const dispatch = (tr) => state = state.apply(tr);
+          const commandResult = goToNextCell(-1)(state, dispatch);
+          ist(commandResult, true);
+          ist(state.selection.from, 7);
+     })
+
+     it("returns true and moves forward one cell if selection is in table, atom node", () => {
+          let state = EditorState.create({
+               doc: docWithSimpleTable,
+               selection: TextSelection.create(docWithSimpleTable, 16)
+          });
+          console.log('here', TableMap.get(state.selection.$from.node(1)))
+          const dispatch = (tr) => state = state.apply(tr);
+          const commandResult = goToNextCell(1)(state, dispatch);
+          ist(commandResult, true);
+          ist(state.selection.from, 19);
+     })
 })

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -507,7 +507,6 @@ describe("goToNextCell", () => {
                doc: docWithSimpleTable,
                selection: TextSelection.create(docWithSimpleTable, 16)
           });
-          console.log('here', TableMap.get(state.selection.$from.node(1)))
           const dispatch = (tr) => state = state.apply(tr);
           const commandResult = goToNextCell(1)(state, dispatch);
           ist(commandResult, true);


### PR DESCRIPTION
## Summary
`goToNextCell` created a `TextSelection` over the text content of a cell and therefore did not work for atom nodes. I modified this function so that it creates a `NodeSelection` if the last child of a cell is an atom node.

Instead of creating a `TextSelection` over all of the text content of a cell, `goToNextCell` will position the cursor at the end of a cell's text content.

## Testing
Manual tests in demo app.
Unit tests.

## Screencaps
**Before:**
![before](https://user-images.githubusercontent.com/72055276/112702460-ecc55e00-8e69-11eb-8351-8f1459547426.gif)


**After:**
![after](https://user-images.githubusercontent.com/72055276/112702468-f18a1200-8e69-11eb-8d7c-ef706b939b17.gif)
