### PR TITLE
Support goToNextCell for Cell w/ Only Atom Nodes

### DIFF
--- a/test/build.js
+++ b/test/build.js
@@ -18,7 +18,8 @@ let e = module.exports = require("prosemirror-test-builder").builders(schema, {
   p: {nodeType: "paragraph"},
   tr: {nodeType: "table_row"},
   td: {nodeType: "table_cell"},
-  th: {nodeType: "table_header"}
+  th: {nodeType: "table_header"},
+  hr: {nodeType: "horizontal_rule"},
 })
 
 e.c = function(colspan, rowspan) {


### PR DESCRIPTION
## Summary
`goToNextCell` used `TextSelection.between` to select the text content of a cell and therefore did not work for atom nodes. I modified this function so that it creates a `NodeSelection` over the cell if the cell contains only atom nodes and no text.

## Testing
Manual tests in demo app.
Unit tests.

## Screencaps
**Before:**
![before](https://user-images.githubusercontent.com/72055276/112702460-ecc55e00-8e69-11eb-8351-8f1459547426.gif)


**After:**
![go to next cell in demo](https://user-images.githubusercontent.com/72055276/113328477-55895c00-92ea-11eb-8678-459cfc3c72c6.gif)

